### PR TITLE
Got account sharing working

### DIFF
--- a/Altoholic/Comm.lua
+++ b/Altoholic/Comm.lua
@@ -128,7 +128,7 @@ function Altoholic:AccSharingHandler(prefix, message, distribution, sender)
 	local self = Altoholic.Comm.Sharing
 
 	if self and self.msgHandler then
-		self[self.msgHandler](self, prefix, message, distribution, sender)
+	    self[self.msgHandler](self, prefix, message, distribution, sender)
 	end
 end
 
@@ -142,17 +142,17 @@ function Altoholic.Comm.Sharing:EmptyHandler(prefix, message, distribution, send
 end
 
 function Altoholic.Comm.Sharing:ActiveHandler(prefix, message, distribution, sender)
-	local success, msgType, msgData
+    local success, msgType, msgData
 	
-	if compressionMode == 1 then	
-		success, msgType, msgData = Altoholic:Deserialize(message)
+	if compressionMode == 1 then
+	    success, msgType, msgData = Altoholic:Deserialize(message)
 --	else
 --		local decompData = LibComp:Decompress(message)
 --		success, msgType, msgData = Altoholic:Deserialize(decompData)
 	end
 	
 	if not success then
-		self.SharingEnabled = nil
+	    self.SharingEnabled = nil
 		-- self:Print(msgType)
 		-- self:Print(string.sub(decompData, 1, 15))
 		return
@@ -278,7 +278,7 @@ function Altoholic.Comm.Sharing:OnSharingRequest(sender, data)
 		Whisper(sender, MSG_ACCOUNT_SHARING_REFUSEDINCOMBAT)
 		return
 	end
-	
+		
 	local auth = Altoholic.Sharing.Clients:GetRights(sender)
 	
 	if not auth then		-- if the sender is not a known client, add him with defaults rights (=ask)
@@ -287,7 +287,7 @@ function Altoholic.Comm.Sharing:OnSharingRequest(sender, data)
 	end
 	
 	if auth == AUTH_AUTO then
-		self:SendSourceTOC(sender)
+	    self:SendSourceTOC(sender)
 	elseif auth == AUTH_ASK then
 		Altoholic:Print(format(L["Account sharing request received from %s"], sender))
 		
@@ -307,7 +307,7 @@ function Altoholic.Comm.Sharing:OnSharingRequest(sender, data)
 end
 
 function Altoholic.Comm.Sharing:SendSourceTOC(sender)
-	self.SharingEnabled = true
+    self.SharingEnabled = true
 	self.SourceTOC = Altoholic.Sharing.Content:GetSourceTOC()
 	-- self.NetSrcCurItem = 0					-- to display that item is 1 of x
 	self.AuthorizedRecipient = sender

--- a/Altoholic/Comm.lua
+++ b/Altoholic/Comm.lua
@@ -128,7 +128,7 @@ function Altoholic:AccSharingHandler(prefix, message, distribution, sender)
 	local self = Altoholic.Comm.Sharing
 
 	if self and self.msgHandler then
-	    self[self.msgHandler](self, prefix, message, distribution, sender)
+		self[self.msgHandler](self, prefix, message, distribution, sender)
 	end
 end
 
@@ -142,17 +142,17 @@ function Altoholic.Comm.Sharing:EmptyHandler(prefix, message, distribution, send
 end
 
 function Altoholic.Comm.Sharing:ActiveHandler(prefix, message, distribution, sender)
-    local success, msgType, msgData
+	local success, msgType, msgData
 	
-	if compressionMode == 1 then
-	    success, msgType, msgData = Altoholic:Deserialize(message)
+	if compressionMode == 1 then	
+		success, msgType, msgData = Altoholic:Deserialize(message)
 --	else
 --		local decompData = LibComp:Decompress(message)
 --		success, msgType, msgData = Altoholic:Deserialize(decompData)
 	end
 	
 	if not success then
-	    self.SharingEnabled = nil
+		self.SharingEnabled = nil
 		-- self:Print(msgType)
 		-- self:Print(string.sub(decompData, 1, 15))
 		return
@@ -278,7 +278,7 @@ function Altoholic.Comm.Sharing:OnSharingRequest(sender, data)
 		Whisper(sender, MSG_ACCOUNT_SHARING_REFUSEDINCOMBAT)
 		return
 	end
-		
+	
 	local auth = Altoholic.Sharing.Clients:GetRights(sender)
 	
 	if not auth then		-- if the sender is not a known client, add him with defaults rights (=ask)
@@ -287,7 +287,7 @@ function Altoholic.Comm.Sharing:OnSharingRequest(sender, data)
 	end
 	
 	if auth == AUTH_AUTO then
-	    self:SendSourceTOC(sender)
+		self:SendSourceTOC(sender)
 	elseif auth == AUTH_ASK then
 		Altoholic:Print(format(L["Account sharing request received from %s"], sender))
 		
@@ -307,7 +307,7 @@ function Altoholic.Comm.Sharing:OnSharingRequest(sender, data)
 end
 
 function Altoholic.Comm.Sharing:SendSourceTOC(sender)
-    self.SharingEnabled = true
+	self.SharingEnabled = true
 	self.SourceTOC = Altoholic.Sharing.Content:GetSourceTOC()
 	-- self.NetSrcCurItem = 0					-- to display that item is 1 of x
 	self.AuthorizedRecipient = sender

--- a/Altoholic/Frames/AccountSharing.lua
+++ b/Altoholic/Frames/AccountSharing.lua
@@ -491,26 +491,27 @@ function Altoholic.Sharing.Content:GetSourceTOC()
 	local toc = {}
 
 	for realm in pairs(DS:GetRealms()) do			-- all realms on this account
-		table.insert(toc, format("%s|%s", TOC_SETREALM, realm))
-	
+	    table.insert(toc, format("%s|%s", TOC_SETREALM, realm))
+			
 		for guildName, guild in pairs(DS:GetGuilds(realm)) do		-- add guilds
-			if isGuildShared(realm, guildName) then
-				table.insert(toc, format("%s|%s", TOC_SETGUILD, guildName))
-				
-				for tabID = 1, 8 do		-- add guild bank tabs
-					local tabName = DS:GetGuildBankTabName(guild, tabID)
-					if tabName and isGuildBankTabShared(realm, guildName, tabID) then
-						serializedData = Altoholic:Serialize(DS:GetGuildBankTab(guild, tabID))
-						lastUpdate = DS:GetGuildBankTabLastUpdate(guild, tabID)
-						table.insert(toc, format("%s|%s|%s|%s|%s", TOC_BANKTAB, tabName, tabID, strlen(serializedData), lastUpdate or 0))
-					end
-				end
+		    if isGuildShared(realm, guildName) then
+			    table.insert(toc, format("%s|%s", TOC_SETGUILD, guildName))
+								
+				--no guild bank in classic
+				--for tabID = 1, 8 do		-- add guild bank tabs
+					--local tabName = DS:GetGuildBankTabName(guild, tabID)
+					--if tabName and isGuildBankTabShared(realm, guildName, tabID) then
+						--serializedData = Altoholic:Serialize(DS:GetGuildBankTab(guild, tabID))
+						--lastUpdate = DS:GetGuildBankTabLastUpdate(guild, tabID)
+						--table.insert(toc, format("%s|%s|%s|%s|%s", TOC_BANKTAB, tabName, tabID, strlen(serializedData), lastUpdate or 0))
+					--end
+				--end
 			end
 		end
 	
 		for characterName, character in pairs(DS:GetCharacters(realm)) do
-			if isCharacterShared(character) then
-				-- get the size of mandatory modules
+		    if isCharacterShared(character) then
+			    -- get the size of mandatory modules
 				local size = 0
 				for k, module in pairs(mandatoryModules) do
 					serializedData = Altoholic:Serialize(DS:GetCharacterTable(module, characterName, realm))
@@ -521,12 +522,15 @@ function Altoholic.Sharing.Content:GetSourceTOC()
 				lastUpdate = DS:GetModuleLastUpdate("DataStore_Characters", characterName, realm)
 				table.insert(toc, format("%s|%s|%s|%s|%s", TOC_SETCHAR, characterName, class, size, lastUpdate or 0))
 				
-				
 				for k, module in pairs(optionalModules) do
-					if isCharacterDataShared(character, module) then
-						-- evaluate the size of transferred data
-						serializedData = Altoholic:Serialize(DS:GetCharacterTable(module, characterName, realm))
-						lastUpdate = DS:GetModuleLastUpdate(module, characterName, realm)
+
+					-- DataStore_Spells and DataStore_Talents aren't working yet
+					if (module ~= "DataStore_Spells" and module ~= "DataStore_Talents") then
+					    if isCharacterDataShared(character, module) then
+    						-- evaluate the size of transferred data
+	    					serializedData = Altoholic:Serialize(DS:GetCharacterTable(module, characterName, realm))
+		    				lastUpdate = DS:GetModuleLastUpdate(module, characterName, realm)
+					    end
 					
 						-- only pass the key to the right datastore module (ex 4 for DataStore_Crafts)
 						table.insert(toc, format("%s|%s|%s|%s", TOC_DATASTORE, k, strlen(serializedData), lastUpdate or 0))
@@ -537,10 +541,11 @@ function Altoholic.Sharing.Content:GetSourceTOC()
 	end
 	
 	-- add reference here
-	for class, _ in pairs(DS:GetReferenceTable()) do
-		serializedData = Altoholic:Serialize(DS:GetClassReference(class))
-		table.insert(toc, format("%s|%s|%s", TOC_REFDATA, class, strlen(serializedData)))
-	end
+	-- whatever this is it doesn't work in classic
+	--for class, _ in pairs(DS:GetReferenceTable()) do
+		--serializedData = Altoholic:Serialize(DS:GetClassReference(class))
+		--table.insert(toc, format("%s|%s|%s", TOC_REFDATA, class, strlen(serializedData)))
+	--end
 	
 	return toc
 end

--- a/Altoholic_Summary/TabSummary.xml
+++ b/Altoholic_Summary/TabSummary.xml
@@ -122,7 +122,7 @@
 				</Scripts>
 			</Button>
 			
-	<!--		<Button parentKey="RequestSharing" inherits="AltoButtonTemplate">    Easier for me to just remove account sharing than port it to classic
+			<Button parentKey="RequestSharing" inherits="AltoButtonTemplate">
 				<Anchors>
 					<Anchor point="TOPRIGHT" relativeKey="$parent.AltoholicOptionsIcon" relativePoint="TOPLEFT" x="-15" y="0" />
 				</Anchors>


### PR DESCRIPTION
I uncommented the account sharing request button on the main frame TabSummary.xml, and commented out the DataStore_Spells and DataStore_Talents from being shared in AccountSharing.lua. Those two datastores would cause the account sharing to lock up. Once they are fixed they can be readded to the account sharing data. I also commented out some reference thing that I didn't understand, but would also cause the account sharing to hang. The shared data works though without it. I also commented out the guild bank sharing, because obviously classic doesn't have guild banks.